### PR TITLE
Feature/favorites

### DIFF
--- a/prisma/migrations/20250915015039_refactor_favorites_schema/migration.sql
+++ b/prisma/migrations/20250915015039_refactor_favorites_schema/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - Added the required column `category` to the `Equipment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Equipment" ADD COLUMN     "category" TEXT NOT NULL,
+ADD COLUMN     "description" TEXT,
+ADD COLUMN     "muscleGroup" TEXT;
+
+-- CreateTable
+CREATE TABLE "Favorite" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "equipmentId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Favorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Favorite_userId_equipmentId_key" ON "Favorite"("userId", "equipmentId");
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_equipmentId_fkey" FOREIGN KEY ("equipmentId") REFERENCES "Equipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250915015821_remove_description_column/migration.sql
+++ b/prisma/migrations/20250915015821_remove_description_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `Equipment` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Equipment" DROP COLUMN "description";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,8 +4,8 @@ generator client {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("DATABASE_URL") // pooled (pgbouncer) 연결
-  directUrl = env("DIRECT_URL") // 직결(마이그레이션용)
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {
@@ -14,19 +14,35 @@ model User {
   name  String
 
   // OAuth 전용 필드
-  googleId String  @unique // Google에서 받은 사용자 ID
-  avatar   String? // 프로필 이미지 URL
+  googleId String  @unique
+  avatar   String?
 
   createdAt    DateTime      @default(now())
   reservations Reservation[]
+  favorites    Favorite[]    // 즐겨찾기 관계 추가
 }
 
 model Equipment {
   id           Int           @id @default(autoincrement())
   name         String        @unique
-  imageUrl     String? // Supabase Storage 이미지 URL
+  imageUrl     String?
+  category     String        // 부위별 카테고리 (가슴, 등, 다리, 어깨, 팔, 유산소 등)
+  muscleGroup  String?       // 세부 근육 그룹 (선택사항)
   createdAt    DateTime      @default(now())
   reservations Reservation[]
+  favorites    Favorite[]    // 즐겨찾기 관계 추가
+}
+
+model Favorite {
+  id          Int       @id @default(autoincrement())
+  userId      Int
+  equipmentId Int
+  createdAt   DateTime  @default(now())
+
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  equipment Equipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, equipmentId]) // 중복 즐겨찾기 방지
 }
 
 model Reservation {
@@ -35,8 +51,8 @@ model Reservation {
   equipmentId Int
   startAt     DateTime
   endAt       DateTime
-  sets        Int      @default(1) // 세트 수
-  restMinutes Int      @default(3) // 세트 간 휴식 시간 (분)
+  sets        Int      @default(1)
+  restMinutes Int      @default(3)
   status      String   @default("BOOKED")
 
   user      User      @relation(fields: [userId], references: [id])

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -4,20 +4,70 @@ const prisma = new PrismaClient({
 })
 
 async function main() {
-  // 헬스장 기구들
+  // 헬스장 기구들 (카테고리 정보 포함)
   const equipmentData = [
-    { name: '스미스 머신', imageUrl: null },
-    { name: '스텝밀', imageUrl: null },
-    { name: '케이블 와이 레이즈', imageUrl: null },
-    { name: '랫풀다운', imageUrl: null },
-    { name: '레그 프레스', imageUrl: null },
-    { name: '레그 컬', imageUrl: null },
-    { name: '어시스티드 머신 친업', imageUrl: null },
-    { name: '바벨 벤치 프레스', imageUrl: null },
-    { name: '백 익스텐션', imageUrl: null },
-    { name: '힙 어브덕션/어덕션', imageUrl: null },
-    { name: '트레드밀', imageUrl: null },
-    { name: '스쿼트 랙', imageUrl: null },
+    { 
+      name: '스미스 머신', 
+      imageUrl: null,
+      category: '가슴',
+      muscleGroup: '가슴, 어깨, 삼두'
+    },
+    { 
+      name: '스텝밀', 
+      imageUrl: null,
+      category: '유산소',
+      muscleGroup: '전신'
+    },
+    { 
+      name: '케이블 와이 레이즈', 
+      imageUrl: null,
+      category: '어깨',
+      muscleGroup: '삼각근, 승모근'    },
+    { 
+      name: '랫풀다운', 
+      imageUrl: null,
+      category: '등',
+      muscleGroup: '광배근, 이두'    },
+    { 
+      name: '레그 프레스', 
+      imageUrl: null,
+      category: '다리',
+      muscleGroup: '대퇴사두근, 둔근'    },
+    { 
+      name: '레그 컬', 
+      imageUrl: null,
+      category: '다리',
+      muscleGroup: '햄스트링'    },
+    { 
+      name: '어시스티드 머신 친업', 
+      imageUrl: null,
+      category: '등',
+      muscleGroup: '광배근, 이두, 어깨'    },
+    { 
+      name: '바벨 벤치 프레스', 
+      imageUrl: null,
+      category: '가슴',
+      muscleGroup: '대흉근, 삼두, 어깨'    },
+    { 
+      name: '백 익스텐션', 
+      imageUrl: null,
+      category: '등',
+      muscleGroup: '척추기립근, 둔근'    },
+    { 
+      name: '힙 어브덕션/어덕션', 
+      imageUrl: null,
+      category: '다리',
+      muscleGroup: '둔근, 허벅지 안쪽'    },
+    { 
+      name: '트레드밀', 
+      imageUrl: null,
+      category: '유산소',
+      muscleGroup: '전신'    },
+    { 
+      name: '스쿼트 랙', 
+      imageUrl: null,
+      category: '다리',
+      muscleGroup: '대퇴사두근, 둔근, 햄스트링'    },
   ]
 
   for (const equipment of equipmentData) {
@@ -25,7 +75,10 @@ async function main() {
       where: { 
         name: equipment.name
       },
-      update: {},
+      update: {
+        category: equipment.category,
+        muscleGroup: equipment.muscleGroup
+      },
       create: equipment
     })
   }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -7,10 +7,10 @@ async function main() {
   // 헬스장 기구들 (카테고리 정보 포함)
   const equipmentData = [
     { 
-      name: '스미스 머신', 
+      name: '스미스 머신 스쿼트', 
       imageUrl: null,
-      category: '가슴',
-      muscleGroup: '가슴, 어깨, 삼두'
+      category: '하체',
+      muscleGroup: '대퇴사두근, 둔근, 햄스트링, 내전근'
     },
     { 
       name: '스텝밀', 
@@ -57,7 +57,7 @@ async function main() {
       name: '힙 어브덕션/어덕션', 
       imageUrl: null,
       category: '다리',
-      muscleGroup: '둔근, 허벅지 안쪽'    },
+      muscleGroup: '둔근, 내전근'    },
     { 
       name: '트레드밀', 
       imageUrl: null,

--- a/src/routes/equipment.js
+++ b/src/routes/equipment.js
@@ -2,45 +2,160 @@ const router = require('express').Router()
 const { PrismaClient } = require('@prisma/client')
 const { auth } = require('../middleware/auth')
 const { z } = require('zod')
+const jwt = require('jsonwebtoken')
 const prisma = new PrismaClient()
 
-// 목록 조회 (공개)
+// 목록 조회 (공개) - 카테고리 필터링 지원
 router.get('/', async (req, res) => {
-  const list = await prisma.equipment.findMany({ 
-    orderBy: { name: 'asc' },
-    include: {
-      _count: {
-        select: { reservations: true }
+  try {
+    const { category, search } = req.query
+    const header = req.headers.authorization || ''
+    const token = header.startsWith('Bearer ') ? header.slice(7) : null
+    let userId = null
+
+    // 토큰이 있으면 사용자 ID 추출 (선택적)
+    if (token) {
+      try {
+        const payload = jwt.verify(token, process.env.JWT_SECRET)
+        userId = payload.id
+      } catch (e) {
+        // 토큰이 유효하지 않아도 목록 조회는 가능
       }
     }
-  })
-  res.json(list)
+
+    // 필터 조건 구성
+    const where = {}
+    if (category && category !== 'all') {
+      where.category = category
+    }
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+        { muscleGroup: { contains: search, mode: 'insensitive' } }
+      ]
+    }
+
+    const list = await prisma.equipment.findMany({ 
+      where,
+      orderBy: { name: 'asc' },
+      include: {
+        _count: {
+          select: { reservations: true }
+        },
+        // 사용자가 로그인했으면 즐겨찾기 정보 포함
+        favorites: userId ? {
+          where: { userId },
+          select: { id: true }
+        } : false
+      }
+    })
+
+    // 응답 데이터 가공
+    const response = list.map(equipment => ({
+      id: equipment.id,
+      name: equipment.name,
+      imageUrl: equipment.imageUrl,
+      category: equipment.category,
+      muscleGroup: equipment.muscleGroup,
+      createdAt: equipment.createdAt,
+      reservationCount: equipment._count.reservations,
+      isFavorite: userId ? equipment.favorites.length > 0 : false
+    }))
+
+    res.json(response)
+  } catch (error) {
+    console.error('기구 목록 조회 오류:', error)
+    res.status(500).json({ error: '기구 목록을 불러올 수 없습니다' })
+  }
+})
+
+// 카테고리 목록 조회
+router.get('/categories', async (req, res) => {
+  try {
+    const categories = await prisma.equipment.groupBy({
+      by: ['category'],
+      _count: {
+        category: true
+      },
+      orderBy: {
+        category: 'asc'
+      }
+    })
+
+    res.json(categories.map(cat => ({
+      name: cat.category,
+      count: cat._count.category
+    })))
+  } catch (error) {
+    console.error('카테고리 조회 오류:', error)
+    res.status(500).json({ error: '카테고리를 불러올 수 없습니다' })
+  }
 })
 
 // 특정 기구 상세 조회
 router.get('/:id', async (req, res) => {
-  const id = Number(req.params.id)
-  const equipment = await prisma.equipment.findUnique({
-    where: { id },
-    include: {
-      reservations: {
-        where: {
-          startAt: { gte: new Date() }
-        },
-        orderBy: { startAt: 'asc' },
-        take: 10,
-        include: {
-          user: { select: { name: true } }
-        }
+  try {
+    const id = Number(req.params.id)
+    const header = req.headers.authorization || ''
+    const token = header.startsWith('Bearer ') ? header.slice(7) : null
+    let userId = null
+
+    // 토큰이 있으면 사용자 ID 추출 (선택적)
+    if (token) {
+      try {
+        const payload = jwt.verify(token, process.env.JWT_SECRET)
+        userId = payload.id
+      } catch (e) {
+        // 토큰이 유효하지 않아도 상세 조회는 가능
       }
     }
-  })
-  
-  if (!equipment) {
-    return res.status(404).json({ error: '기구를 찾을 수 없습니다' })
+
+    const equipment = await prisma.equipment.findUnique({
+      where: { id },
+      include: {
+        reservations: {
+          where: {
+            startAt: { gte: new Date() }
+          },
+          orderBy: { startAt: 'asc' },
+          take: 10,
+          include: {
+            user: { select: { name: true } }
+          }
+        },
+        favorites: userId ? {
+          where: { userId },
+          select: { id: true }
+        } : false,
+        _count: {
+          select: { favorites: true }
+        }
+      }
+    })
+    
+    if (!equipment) {
+      return res.status(404).json({ error: '기구를 찾을 수 없습니다' })
+    }
+
+    // 응답 데이터 가공
+    const response = {
+      id: equipment.id,
+      name: equipment.name,
+      imageUrl: equipment.imageUrl,
+      category: equipment.category,
+      muscleGroup: equipment.muscleGroup,
+      createdAt: equipment.createdAt,
+      reservations: equipment.reservations,
+      isFavorite: userId ? equipment.favorites.length > 0 : false,
+      favoriteCount: equipment._count.favorites
+    }
+    
+    res.json(response)
+  } catch (error) {
+    console.error('기구 상세 조회 오류:', error)
+    res.status(500).json({ error: '기구 정보를 불러올 수 없습니다' })
   }
-  
-  res.json(equipment)
 })
 
 module.exports = router

--- a/src/routes/favorites.js
+++ b/src/routes/favorites.js
@@ -1,0 +1,146 @@
+const router = require('express').Router()
+const { PrismaClient } = require('@prisma/client')
+const { auth } = require('../middleware/auth')
+const prisma = new PrismaClient()
+
+// 내 즐겨찾기 목록 조회
+router.get('/', auth(), async (req, res) => {
+  try {
+    const favorites = await prisma.favorite.findMany({
+      where: { userId: req.user.id },
+      include: {
+        equipment: {
+          include: {
+            _count: {
+              select: { reservations: true }
+            }
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' }
+    })
+    
+    res.json(favorites.map(fav => ({
+      id: fav.id,
+      createdAt: fav.createdAt,
+      equipment: {
+        id: fav.equipment.id,
+        name: fav.equipment.name,
+        imageUrl: fav.equipment.imageUrl,
+        category: fav.equipment.category,
+        muscleGroup: fav.equipment.muscleGroup,
+        reservationCount: fav.equipment._count.reservations,
+        isFavorite: true
+      }
+    })))
+  } catch (error) {
+    console.error('즐겨찾기 조회 오류:', error)
+    res.status(500).json({ error: '즐겨찾기를 불러올 수 없습니다' })
+  }
+})
+
+// 즐겨찾기 추가
+router.post('/', auth(), async (req, res) => {
+  try {
+    const { equipmentId } = req.body
+    
+    if (!equipmentId || typeof equipmentId !== 'number') {
+      return res.status(400).json({ error: 'equipmentId가 필요합니다' })
+    }
+
+    // 기구 존재 확인
+    const equipment = await prisma.equipment.findUnique({
+      where: { id: equipmentId }
+    })
+    
+    if (!equipment) {
+      return res.status(404).json({ error: '기구를 찾을 수 없습니다' })
+    }
+
+    // 이미 즐겨찾기에 있는지 확인
+    const existing = await prisma.favorite.findUnique({
+      where: {
+        userId_equipmentId: {
+          userId: req.user.id,
+          equipmentId: equipmentId
+        }
+      }
+    })
+
+    if (existing) {
+      return res.status(409).json({ error: '이미 즐겨찾기에 추가된 기구입니다' })
+    }
+
+    const favorite = await prisma.favorite.create({
+      data: {
+        userId: req.user.id,
+        equipmentId: equipmentId
+      },
+      include: {
+        equipment: true
+      }
+    })
+
+    res.status(201).json({
+      id: favorite.id,
+      createdAt: favorite.createdAt,
+      equipment: {
+        ...favorite.equipment,
+        isFavorite: true
+      }
+    })
+  } catch (error) {
+    console.error('즐겨찾기 추가 오류:', error)
+    res.status(500).json({ error: '즐겨찾기 추가에 실패했습니다' })
+  }
+})
+
+// 즐겨찾기 제거
+router.delete('/equipment/:equipmentId', auth(), async (req, res) => {
+  try {
+    const equipmentId = Number(req.params.equipmentId)
+    
+    if (!equipmentId) {
+      return res.status(400).json({ error: '유효하지 않은 기구 ID입니다' })
+    }
+
+    const deleted = await prisma.favorite.deleteMany({
+      where: {
+        userId: req.user.id,
+        equipmentId: equipmentId
+      }
+    })
+
+    if (deleted.count === 0) {
+      return res.status(404).json({ error: '즐겨찾기에서 찾을 수 없습니다' })
+    }
+
+    res.status(204).end()
+  } catch (error) {
+    console.error('즐겨찾기 제거 오류:', error)
+    res.status(500).json({ error: '즐겨찾기 제거에 실패했습니다' })
+  }
+})
+
+// 특정 기구가 즐겨찾기인지 확인
+router.get('/check/:equipmentId', auth(), async (req, res) => {
+  try {
+    const equipmentId = Number(req.params.equipmentId)
+    
+    const favorite = await prisma.favorite.findUnique({
+      where: {
+        userId_equipmentId: {
+          userId: req.user.id,
+          equipmentId: equipmentId
+        }
+      }
+    })
+
+    res.json({ isFavorite: !!favorite })
+  } catch (error) {
+    console.error('즐겨찾기 확인 오류:', error)
+    res.status(500).json({ error: '즐겨찾기 상태를 확인할 수 없습니다' })
+  }
+})
+
+module.exports = router

--- a/src/server.js
+++ b/src/server.js
@@ -4,26 +4,22 @@ const cors = require('cors')
 const session = require('express-session')
 const { PrismaClient } = require('@prisma/client')
 
-
 // Passport 설정 import
 require('./config/passport')
-
 
 const authRoutes = require('./routes/auth')
 const equipmentRoutes = require('./routes/equipment')
 const reservationRoutes = require('./routes/reservations')
-
+const favoriteRoutes = require('./routes/favorites')
 
 const app = express()
 const prisma = new PrismaClient()
-
 
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:3000',
   credentials: true
 }))
 app.use(express.json())
-
 
 // 세션 설정
 app.use(session({
@@ -36,33 +32,28 @@ app.use(session({
   }
 }))
 
-
 // Passport 초기화
 const passport = require('passport')
 app.use(passport.initialize())
 app.use(passport.session())
 
-
 app.get('/health', (_, res) => res.json({ ok: true, time: new Date().toISOString() }))
-
 
 app.use('/api/auth', authRoutes)
 app.use('/api/equipment', equipmentRoutes)
 app.use('/api/reservations', reservationRoutes)
-
+app.use('/api/favorites', favoriteRoutes)
 
 // 404
 app.use((req, res, next) => {
   res.status(404).json({ error: 'Not Found' })
 })
 
-
 // Error handler
 app.use((err, req, res, next) => {
   console.error(err)
   res.status(err.status || 500).json({ error: err.message || 'Server Error' })
 })
-
 
 const port = process.env.PORT || 4000
 app.listen(port, () => console.log(`API on http://localhost:${port}`))


### PR DESCRIPTION
1) 요약

기구 카테고리 분류와 즐겨찾기를 백엔드에서 지원

첫 번째 이미지 기준:

⭐ 별표 클릭으로 즐겨찾기 추가/제거

즐겨찾기 탭에서 내가 즐겨찾기한 기구만 보기

부위별 탭(가슴, 등, 다리, 어깨, 팔, 유산소 등) 필터링

검색어로 기구 이름/설명 검색
2) 사용법 (API 엔드포인트)
2-1. 기구 목록 (카테고리/검색 필터)

카테고리 필터:

GET /api/equipment?category=가슴

GET /api/equipment?category=다리

검색(이름/설명):

GET /api/equipment?search=벤치

카테고리+검색 조합도 가능:

GET /api/equipment?category=등&search=로우

2-2. 카테고리 목록

GET /api/equipment/categories

프런트 탭/필터 드롭다운 구성에 사용

2-3. 즐겨찾기 관리

내 즐겨찾기 목록:

GET /api/favorites

즐겨찾기 추가:

POST /api/favorites

{ "equipmentId": 3 }


즐겨찾기 제거:

DELETE /api/favorites/equipment/:equipmentId

즐겨찾기 여부 확인:

GET /api/favorites/check/:equipmentId → { "isFavorite": true | false }

3) 프런트 연동 포인트

리스트/카드의 ⭐ 토글:

isFavorite 확인 → POST / DELETE로 토글

“즐겨찾기 탭”:

탭 진입 시 GET /api/favorites

“부위별 탭”:

선택된 탭명을 category 쿼리로 전달

검색:

입력값을 search 쿼리로 전달(디바운스 권장)

4) 테스트 체크리스트

 GET /api/equipment 기본 목록 반환

 category 필터별로 예상 개수/아이템 반환

 search가 이름/설명에 매칭되는지 확인

 즐겨찾기 추가/제거 후 목록/상태 확인 일치

 로그인/세션 요구 엔드포인트(즐겨찾기) 인증 처리 정상

 성능: 카테고리/검색 인덱스가 필요한 경우 확인