### PR TITLE
feat(routine): switch restMinutes→restSeconds across schema & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 - **실시간 알림**: WebSocket을 통한 즉시 알림
 
 ## Backend API 문서
+### 👉수정 혹은 추가된 API
+-
 ### 🔑 Auth API
 - `GET /api/auth/google` - Google OAuth 로그인 시작
 - `GET /api/auth/google/callback` - OAuth 콜백 처리

--- a/prisma/migrations/20250925210407_rename_rest_minutes_to_rest_seconds_routine_exercise/migration.sql
+++ b/prisma/migrations/20250925210407_rename_rest_minutes_to_rest_seconds_routine_exercise/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `restMinutes` on the `RoutineExercise` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."RoutineExercise" DROP COLUMN "restMinutes",
+ADD COLUMN     "restSeconds" INTEGER NOT NULL DEFAULT 180;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model EquipmentUsage {
   estimatedEndAt DateTime? // 예상 종료 시간 (선택사항)
   // 총 세트 & 휴식
   totalSets      Int       @default(1) // 총 세트 수
-  restSeconds    Int       @default(180) // 세트 사이 휴식(분)
+  restSeconds    Int       @default(180) // 세트 사이 휴식(초)
 
   // 세션 상태
   status String @default("IN_USE") // IN_USE | COMPLETED
@@ -128,7 +128,7 @@ model RoutineExercise {
   order       Int // 루틴 내 순서
   targetSets  Int      @default(3)
   targetReps  String? // "8-12" 또는 "10" 형태
-  restMinutes Int      @default(3)
+  restSeconds Int      @default(180)
   notes       String? // 개인 메모 (무게, 특이사항 등)
   createdAt   DateTime @default(now())
 

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -7,7 +7,7 @@ async function main() {
   // 헬스장 기구들 (카테고리 정보 포함)
   const equipmentData = [
     { 
-      name: '스미스 머신 스쿼트', 
+      name: '스미스 머신', 
       imageUrl: null,
       category: '다리',
       muscleGroup: '대퇴사두근, 둔근, 햄스트링, 내전근'
@@ -19,7 +19,7 @@ async function main() {
       muscleGroup: '전신'
     },
     { 
-      name: '케이블 와이 레이즈', 
+      name: '케이블머신', 
       imageUrl: null,
       category: '어깨',
       muscleGroup: '삼각근, 승모근'    },
@@ -29,22 +29,22 @@ async function main() {
       category: '등',
       muscleGroup: '광배근, 이두'    },
     { 
-      name: '레그 프레스', 
+      name: '레그프레스', 
       imageUrl: null,
       category: '다리',
       muscleGroup: '대퇴사두근, 둔근'    },
     { 
-      name: '레그 컬', 
+      name: '레그컬', 
       imageUrl: null,
       category: '다리',
       muscleGroup: '햄스트링'    },
     { 
-      name: '어시스티드 머신 친업', 
+      name: '풀업', 
       imageUrl: null,
       category: '등',
       muscleGroup: '광배근, 이두, 어깨'    },
     { 
-      name: '바벨 벤치 프레스', 
+      name: '벤치 프레스', 
       imageUrl: null,
       category: '가슴',
       muscleGroup: '대흉근, 삼두, 어깨'    },
@@ -54,7 +54,7 @@ async function main() {
       category: '등',
       muscleGroup: '척추기립근, 둔근'    },
     { 
-      name: '힙 어브덕션/어덕션', 
+      name: '힙 어브덕션/힙 어덕션', 
       imageUrl: null,
       category: '다리',
       muscleGroup: '둔근, 내전근'    },
@@ -62,12 +62,7 @@ async function main() {
       name: '트레드밀', 
       imageUrl: null,
       category: '유산소',
-      muscleGroup: '전신'    },
-    { 
-      name: '스쿼트 랙', 
-      imageUrl: null,
-      category: '다리',
-      muscleGroup: '대퇴사두근, 둔근, 햄스트링'    },
+      muscleGroup: '전신'    }
   ]
 
   for (const equipment of equipmentData) {

--- a/src/schemas/routine.schema.js
+++ b/src/schemas/routine.schema.js
@@ -4,7 +4,7 @@ const routineExercise = z.object({
   equipmentId: z.number().int().positive(),
   targetSets: z.number().int().min(1).max(20).default(3),
   targetReps: z.string().optional(),
-  restMinutes: z.number().int().min(0).max(15).default(3),
+  restSeconds: z.number().int().min(0).max(900).default(180),
   notes: z.string().optional(),
 });
 


### PR DESCRIPTION
- schema: RoutineExercise.restSeconds(Int, default 180), migration with minutes→seconds conversion
- APIs: request/response keys now restSeconds; durationSeconds/totalSeconds; estimatedWaitSeconds
- remove unused toMinutes import