### PR TITLE
feat(routines): exercise upsert + rest-time adjust in 10s steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@
 
 ## Backend API 문서
 ### 👉수정 혹은 추가된 API
--
+- `PUT /api/routines/active-usage/rest-time` - +/- 10초 조정
+- `GET /api/routines/active-usage/status`- 현재 운동 상태 True/False
+- `POST /api/routines/:id/exercises` - 운동 추가/업데이트
+
 ### 🔑 Auth API
 - `GET /api/auth/google` - Google OAuth 로그인 시작
 - `GET /api/auth/google/callback` - OAuth 콜백 처리
@@ -68,6 +71,8 @@
 - `DELETE /api/routines/:id` - 운동 루틴 삭제
 - `POST /api/routines/:routineId/exercises/:exerciseId/start` - 루틴의 특정 운동 즉시 시작(기구 사용시작)
 - `POST /api/routines/:routineId/exercises/:exerciseId/queue` - 루틴의 특정 운동 대기열 등록
+- `PUT /api/routines/active-usage/rest-time` - 휴식타이머 +-10초 간격 조정
+- `GET /api/routines/active-usage/status`- 현재 운동 상태 True/False
 
 # 📋 요청 바디, 응답 바디
 
@@ -117,6 +122,42 @@ Authorization: Bearer <token>
 ```
 
 ## 2. 기구 (Equipment) API
+### 2.0 기구 전체 목록 조회
+GET /api/equipment
+```
+**요청바디**: 없음
+**쿼리 파라미터**:
+{
+        "id": 4,
+        "name": "랫풀다운",
+        "imageUrl": null,
+        "category": "등",
+        "muscleGroup": "광배근, 이두",
+        "createdAt": "2025-09-25T08:31:11.471Z",
+        "isFavorite": false,
+        "status": {
+            "isAvailable": true,
+            "equipmentStatus": "available",
+            "statusMessage": "사용 가능",
+            "statusColor": "green",
+            "currentUser": null,
+            "currentUserStartedAt": null,
+            "currentUsageInfo": null,
+            "waitingCount": 0,
+            "myQueuePosition": null,
+            "myQueueStatus": null,
+            "canStart": false,
+            "canQueue": false,
+            "completedToday": false,
+            "lastCompletedAt": null,
+            "lastCompletedSets": null,
+            "lastCompletedTotalSets": null,
+            "lastCompletedDurationSeconds": null,
+            "wasFullyCompleted": false,
+            "recentCompletion": null
+        }
+    },.... 모든 기구 조회 가능
+```
 
 ### 2.1 기구 목록 조회
 ```
@@ -615,54 +656,235 @@ Authorization: Bearer <token>
 }
 ```
 
-## 5. 루틴 (Routines) API
-
-### 5.1 루틴 목록 조회
-```
-GET /api/routines?isActive=true
-Authorization: Bearer <token>
-```
-**요청바디**: 없음  
-**응답바디**:
+## 5. 루틴 (Routines) API(JWT 필요)
+### 5.1 내 운동 루틴 목록 조회
+GET /api/routines
+**요청바디** : 없음
+**응답바디** : 
 ```json
 [
   {
-    "id": 1,뀜
+    "id": 7,
+    "name": "하체 루틴",
+    "isActive": true,
+    "exerciseCount": 2,
+    "createdAt": "2025-09-25T23:15:28.222Z",
+    "updatedAt": "2025-09-25T23:15:28.222Z",
+    "exercises": [
+      {
+        "id": 8,
+        "routineId": 7,
+        "equipmentId": 1,
+        "order": 1,
+        "targetSets": 3,
+        "targetReps": null,
+        "restSeconds": 180,
+        "notes": null,
+        "createdAt": "2025-09-25T23:15:28.222Z",
+        "equipment": {
+          "id": 1,
+          "name": "스미스 머신 스쿼트",
+          "imageUrl": null,
+          "category": "다리",
+          "muscleGroup": "대퇴사두근, 둔근, 햄스트링, 내전근"
+        }
+      }
+    ]
+  }
+]
 ```
-**요청바디**: 없음  
-**응답바디**:
+
+### 5.2 특정 루틴 상세 조회
+GET /api/routines/:id
+**요청바디** : 없음 path params : id
+**응답바디** : 
 ```json
 {
-  "equipmentId": 1,
-  "equipmentName": "벤치프레스",
-  "isAvailable": false,
-  "lastUpdated": "2025-01-15T10:30:00.000Z",
-  "currentUser": {
-    "name": "홍길동",
-    "startedAt": "2025-01-15T10:00:00.000Z",
-    "totalSets": 3,
-    "currentSet": 2,
-    "setStatus": "EXERCISING",
-    "restSeconds": 180,
-    "progress": 67,
-    "setProgress": 45,
-    "estimatedMinutesLeft": 8,
-    "restTimeLeft": 0
-  },
-  "waitingQueue": [
+  "id": 7,
+  "name": "하체 루틴",
+  "isActive": true,
+  "createdAt": "2025-09-25T23:15:28.222Z",
+  "updatedAt": "2025-09-25T23:15:28.222Z",
+  "exercises": [
     {
-      "id": 1,
-      "position": 1,
-      "userName": "김철수",
-      "status": "WAITING",
-      "createdAt": "2025-01-15T10:25:00.000Z",
-      "estimatedWaitMinutes": 10
+      "id": 8,
+      "order": 1,
+      "targetSets": 3,
+      "targetReps": null,
+      "restSeconds": 180,
+      "notes": null,
+      "equipment": {
+        "id": 1,
+        "name": "스미스 머신 스쿼트",
+        "imageUrl": null,
+        "category": "다리",
+        "muscleGroup": "대퇴사두근, 둔근, 햄스트링, 내전근"
+      },
+      "status": {
+        "isAvailable": false,
+        "currentUser": "홍길동",
+        "currentUserStartedAt": "2025-09-25T23:05:00.000Z",
+        "waitingCount": 2,
+        "myQueuePosition": null,
+        "myQueueStatus": null,
+        "canStart": false,
+        "canQueue": true
+      }
     }
   ],
-  "totalWaiting": 1,
-  "averageWaitTime": 10
+  "currentlyUsing": {
+    "equipmentId": 1,
+    "equipmentName": "스미스 머신 스쿼트"
+  }
 }
 ```
+
+### 5.3 새로운 루틴 생성
+POST /api/routines
+**요청바디** :
+```json 
+{
+  "name": "Postman Test Routine",
+  "exercises": [
+    { "equipmentId": 1, "targetSets": 3, "restSeconds": 180 },
+    { "equipmentId": 2, "targetSets": 4, "restSeconds": 180 }
+  ]
+}
+```
+**응답바디** : (201 created)
+```json
+{
+  "id": 7,
+  "name": "Postman Test Routine",
+  "isActive": true,
+  "exerciseCount": 2,
+  "exercises": [
+    {
+      "id": 8,
+      "routineId": 7,
+      "equipmentId": 1,
+      "order": 1,
+      "targetSets": 3,
+      "targetReps": null,
+      "restSeconds": 180,
+      "notes": null,
+      "createdAt": "2025-09-25T23:15:28.222Z",
+      "equipment": {
+        "id": 1,
+        "name": "스미스 머신 스쿼트",
+        "imageUrl": null,
+        "category": "다리",
+        "muscleGroup": "대퇴사두근, 둔근, 햄스트링, 내전근"
+      }
+    },
+    {
+      "id": 9,
+      "routineId": 7,
+      "equipmentId": 2,
+      "order": 2,
+      "targetSets": 4,
+      "targetReps": null,
+      "restSeconds": 180,
+      "notes": null,
+      "createdAt": "2025-09-25T23:15:28.222Z",
+      "equipment": {
+        "id": 2,
+        "name": "레그 프레스",
+        "imageUrl": null,
+        "category": "다리",
+        "muscleGroup": "대퇴사두근, 둔근, 햄스트링"
+      }
+    }
+  ],
+  "createdAt": "2025-09-25T23:15:28.222Z",
+  "updatedAt": "2025-09-25T23:15:28.222Z"
+}
+```
+### 5.4 루틴 수정
+PUT /api/routines/:id
+**요청바디** : 수정하고 싶은 내용 
+**응답바디** : 
+```json
+{
+  "name": "업데이트된 하체 루틴",
+  "isActive": true,
+  "exercises": [
+    { "equipmentId": 1, "targetSets": 4, "restSeconds": 150, "notes": "스쿼트 템포 느리게" },
+    { "equipmentId": 3, "targetSets": 3, "restSeconds": 180 }
+  ]
+}
+
+```
+### 5.5 루틴 삭제
+DELETE /api/routines
+**요청바디** :  
+**응답바디** : (204 No Content)
+
+### 5.6 특정 운동 즉시 시작
+POST /api/routines/:routineId/exercises/:exerciseId/start
+**요청바디** : 
+```json
+{ "totalSets": 3, "restSeconds": 180 }
+```
+**응답바디** : 
+```json
+{
+  "message": "스미스 머신 스쿼트 사용을 시작했습니다",
+  "equipmentName": "스미스 머신 스쿼트",
+  "totalSets": 3,
+  "restSeconds": 180,
+  "usageId": 7
+}
+
+```
+
+### 5.7 휴식 타이머 +- 10초 조정
+PUT /api/routines/active-usage/rest-time
+**요청바디** : 
+```json
+{ "adjustment": 10 }   // 또는 -10
+```
+**응답바디** : 
+```json
+{
+  "message": "휴식시간이 증가했습니다",
+  "equipmentName": "벤치프레스",
+  "previousRestSeconds": 170,
+  "newRestSeconds": 180,
+  "adjustment": 10,
+  "currentSet": 2,
+  "totalSets": 3,
+  "setStatus": "RESTING"
+}
+
+```
+
+### 5.8 현재 운동 상태 
+GET /api/routines/active-usage/status
+**요청바디** : 없음
+**응답바디** : 
+응답 예시 (활성 X)
+```json
+{ "active": false }
+
+```
+응답 예시 (활성 O)
+```json
+{
+  "active": true,
+  "usageId": 10,
+  "equipmentId": 1,
+  "equipmentName": "벤치프레스",
+  "totalSets": 3,
+  "currentSet": 2,
+  "setStatus": "RESTING",
+  "restSeconds": 180,
+  "restTimeLeft": 75,
+  "setProgress": 0
+}
+
+```
+
 ## 🌐 WebSocket API
 
 ### WebSocket 연결

--- a/src/schemas/routine.schema.js
+++ b/src/schemas/routine.schema.js
@@ -17,4 +17,25 @@ const updateRoutineSchema = createRoutineSchema.partial().extend({
   isActive: z.boolean().optional(),
 });
 
-module.exports = { createRoutineSchema, updateRoutineSchema };
+// 🆕 개별 운동 추가/업데이트용 스키마
+const addExerciseSchema = z.object({
+  equipmentId: z.number().int().positive(),
+  targetSets: z.number().int().min(1).max(20).default(3),
+  targetReps: z.string().optional(),
+  restSeconds: z.number().int().min(0).max(900).default(180), // 초 단위
+  notes: z.string().optional(),
+});
+
+// 🆕 휴식시간 조정용 스키마
+const adjustRestTimeSchema = z.object({
+  adjustment: z.number().int().refine(val => [10, -10].includes(val), {
+    message: "조정값은 +10 또는 -10 초만 가능합니다"
+  })
+});
+
+module.exports = { 
+  createRoutineSchema, 
+  updateRoutineSchema, 
+  addExerciseSchema,
+  adjustRestTimeSchema
+};

--- a/src/services/equipment.service.js
+++ b/src/services/equipment.service.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
-// 기구 상태, 내 대기/사용, 오늘 완료 내역까지 한 번에
+// 기구 상태, 내 대기/사용, 오늘 완료 내역, 최근 완료 정보까지 한 번에
 async function getEquipmentStatusInfo(equipmentIds, userId = null) {
   const [currentUsages, waitingQueues] = await Promise.all([
     prisma.equipmentUsage.findMany({
@@ -17,6 +17,7 @@ async function getEquipmentStatusInfo(equipmentIds, userId = null) {
   let myQueues = [];
   let myCurrentUsage = null;
   let myCompletedToday = new Map();
+  let recentCompletions = new Map(); // 🆕 최근 완료 정보
 
   if (userId) {
     [myQueues, myCurrentUsage] = await Promise.all([
@@ -31,17 +32,49 @@ async function getEquipmentStatusInfo(equipmentIds, userId = null) {
     const completed = await prisma.equipmentUsage.findMany({
       where: { userId, equipmentId: { in: equipmentIds }, status: 'COMPLETED', endedAt: { gte: sod } },
       orderBy: { endedAt: 'desc' },
+      include: { user: { select: { name: true } } },
     });
 
     completed.forEach((u) => {
       if (!myCompletedToday.has(u.equipmentId)) {
-        const duration = u.startedAt && u.endedAt ? Math.round((u.endedAt - u.startedAt) / 60000) : null;
+        const duration = u.startedAt && u.endedAt ? Math.round((u.endedAt - u.startedAt) / 1000) : null;
         myCompletedToday.set(u.equipmentId, {
           status: u.status,
           lastCompletedAt: u.endedAt,
           totalSets: u.totalSets,
+          completedSets: u.currentSet,
           setStatus: u.setStatus,
-          duration,
+          durationSeconds: duration,
+        });
+      }
+    });
+
+    // 🆕 최근 10분 이내 완료된 운동 조회 (다른 사용자들도 포함)
+    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+    const recentCompletedUsages = await prisma.equipmentUsage.findMany({
+      where: { 
+        equipmentId: { in: equipmentIds }, 
+        status: 'COMPLETED', 
+        endedAt: { gte: tenMinutesAgo } 
+      },
+      include: { user: { select: { name: true } } },
+      orderBy: { endedAt: 'desc' },
+    });
+
+    recentCompletedUsages.forEach((u) => {
+      const existing = recentCompletions.get(u.equipmentId);
+      if (!existing || u.endedAt > existing.endedAt) {
+        const duration = u.startedAt && u.endedAt ? Math.round((u.endedAt - u.startedAt) / 1000) : null;
+        recentCompletions.set(u.equipmentId, {
+          userName: u.user.name,
+          isMe: u.userId === userId,
+          completedAt: u.endedAt,
+          totalSets: u.totalSets,
+          completedSets: u.currentSet,
+          setStatus: u.setStatus,
+          durationSeconds: duration,
+          wasFullyCompleted: u.setStatus === 'COMPLETED',
+          wasInterrupted: ['STOPPED', 'FORCE_COMPLETED'].includes(u.setStatus),
         });
       }
     });
@@ -57,9 +90,37 @@ async function getEquipmentStatusInfo(equipmentIds, userId = null) {
     const canQueue = !isAvailable && !myQ && (!myCurrentUsage || myCurrentUsage.equipmentId === id);
 
     const myCompleted = userId ? myCompletedToday.get(id) || null : null;
+    const recentCompletion = userId ? recentCompletions.get(id) || null : null;
+
+    // 🆕 기구 상태 결정 로직
+    let equipmentStatus = 'available'; // available | in_use | recently_completed
+    let statusMessage = '사용 가능';
+    let statusColor = 'green';
+
+    if (cu) {
+      equipmentStatus = 'in_use';
+      statusMessage = `${cu.user.name} 사용 중`;
+      statusColor = 'orange';
+    } else if (recentCompletion) {
+      equipmentStatus = 'recently_completed';
+      const minutesAgo = Math.round((Date.now() - recentCompletion.completedAt.getTime()) / 60000);
+      if (recentCompletion.isMe) {
+        statusMessage = `방금 완료 (${minutesAgo}분 전)`;
+        statusColor = 'blue';
+      } else {
+        statusMessage = `${recentCompletion.userName} 완료 (${minutesAgo}분 전)`;
+        statusColor = 'gray';
+      }
+    }
 
     statusMap.set(id, {
+      // 기본 상태 정보
       isAvailable,
+      equipmentStatus, // 🆕 추가
+      statusMessage,   // 🆕 추가
+      statusColor,     // 🆕 추가
+      
+      // 현재 사용자 정보
       currentUser: cu ? cu.user.name : null,
       currentUserStartedAt: cu ? cu.startedAt : null,
       currentUsageInfo: cu
@@ -72,17 +133,37 @@ async function getEquipmentStatusInfo(equipmentIds, userId = null) {
             estimatedEndAt: cu.estimatedEndAt,
           }
         : null,
+
+      // 대기열 정보
       waitingCount: queueCount,
       myQueuePosition: myQ ? myQ.queuePosition : null,
       myQueueStatus: myQ ? myQ.status : null,
       canStart: !!userId && canStart,
       canQueue: !!userId && canQueue,
 
+      // 내 완료 기록 (오늘)
       completedToday: !!myCompleted,
       lastCompletedAt: myCompleted?.lastCompletedAt ?? null,
-      lastCompletedSets: myCompleted?.totalSets ?? null,
-      lastCompletedDuration: myCompleted?.duration ?? null,
-      wasFullyCompleted: myCompleted?.status === 'COMPLETED',
+      lastCompletedSets: myCompleted?.completedSets ?? null,
+      lastCompletedTotalSets: myCompleted?.totalSets ?? null,
+      lastCompletedDurationSeconds: myCompleted?.durationSeconds ?? null,
+      wasFullyCompleted: myCompleted?.setStatus === 'COMPLETED',
+
+      // 🆕 최근 완료 정보 (10분 이내, 모든 사용자)
+      recentCompletion: recentCompletion ? {
+        userName: recentCompletion.userName,
+        isMe: recentCompletion.isMe,
+        completedAt: recentCompletion.completedAt,
+        minutesAgo: Math.round((Date.now() - recentCompletion.completedAt.getTime()) / 60000),
+        totalSets: recentCompletion.totalSets,
+        completedSets: recentCompletion.completedSets,
+        durationSeconds: recentCompletion.durationSeconds,
+        wasFullyCompleted: recentCompletion.wasFullyCompleted,
+        wasInterrupted: recentCompletion.wasInterrupted,
+        completionRate: recentCompletion.totalSets > 0 
+          ? Math.round((recentCompletion.completedSets / recentCompletion.totalSets) * 100) 
+          : 0,
+      } : null,
     });
   });
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -215,12 +215,40 @@ function broadcastETAUpdate(equipmentId, etaData) {
   })
 }
 
-// 기구 상태 변경 브로드캐스트
+// 기구 상태 변경 브로드캐스트 (개선됨)
 function broadcastEquipmentStatusChange(equipmentId, statusData) {
   return broadcastToEquipmentSubscribers(equipmentId, {
     type: 'status_changed',
     data: statusData
   })
+}
+
+// 🆕 운동 완료 브로드캐스트 (특별 처리)
+function broadcastWorkoutCompletion(equipmentId, completionData) {
+  const message = {
+    type: 'workout_completed',
+    equipmentId,
+    data: {
+      ...completionData,
+      showCompletionBadge: true, // 프론트엔드에서 완료 배지 표시 플래그
+      completionDisplayDuration: 300000, // 5분간 표시
+    }
+  }
+
+  // 해당 기구 구독자들에게 브로드캐스트
+  const broadcastCount = broadcastToEquipmentSubscribers(equipmentId, message)
+
+  // 🎉 완료자에게 축하 메시지
+  sendNotification(completionData.userId, {
+    type: 'WORKOUT_COMPLETED',
+    title: '🎉 운동 완료!',
+    message: `${completionData.equipmentName} ${completionData.completedSets}/${completionData.totalSets} 세트 완료`,
+    equipmentId,
+    completionData,
+    celebrationEmoji: completionData.wasFullyCompleted ? '🎉' : '👍'
+  })
+
+  return broadcastCount
 }
 
 // 연결 상태 모니터링 (Ping/Pong)
@@ -361,6 +389,7 @@ module.exports = {
   sendNotification,
   broadcastETAUpdate,
   broadcastEquipmentStatusChange,
+  broadcastWorkoutCompletion, // 🆕 추가
   getWebSocketStats,
   equipmentSubscribers // 디버깅용 export
 }


### PR DESCRIPTION
## 요약
- **루틴 운동 업서트**: 기존 루틴에 없는 운동이 들어오면 추가, 있으면 갱신
- **휴식시간 10초 단위 조정**: 액티브 사용 중인 루틴/운동에 대해 `±10s` 증감
- **시간 단위 통일**: 모든 API에서 `restSeconds`를 **초 단위**로 사용
- **장비 상태 응답 확장**: 최근 완료 정보/상태 컬러/메시지 등 추가 필드 대응
  (문서 근거: 내부 정리 파일 참조) :contentReference[oaicite:1]{index=1}

## 변경 상세
- API
  - (예) `POST /api/routines/:id/exercises` → **업서트** 동작
  - (예) `PUT /api/routines/active-usage/rest-time` → **±10초** 조정
  - (예) `GET /api/routines/active-usage/status` → 현 상태 질의
- 스키마/로직
  - `restSeconds`를 전 구간 초 단위로 통일
  - (필요 시) durationSeconds 사용, minutes 제거 검토
- WebSocket
  - `workout_completed`, `rest_time_adjusted` 이벤트 핸들러 반영(프론트 가이드 포함)

## 호환성/영향
- **Breaking**: `restSeconds`가 초 단위로 고정됨에 따라, 프론트 타이머/표시 로직 수정 필요
- **Non-breaking**: 신규 엔드포인트는 추가 형태