### PR TITLE
feat(auth): 12시간 만료 게스트 로그인 + 주기적 만료 계정 정리 + 컬럼Cascade(연관데이터삭제관련) 

### DIFF
--- a/prisma/migrations/20251217135830_guest_login_column_update/migration.sql
+++ b/prisma/migrations/20251217135830_guest_login_column_update/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "guestExpiresAt" TIMESTAMP(3),
+ADD COLUMN     "isGuest" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20251217141128_fix_missing_column/migration.sql
+++ b/prisma/migrations/20251217141128_fix_missing_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."User" ALTER COLUMN "googleId" DROP NOT NULL;

--- a/prisma/migrations/20251217181257_fix_equipment_usage_cascade_delete/migration.sql
+++ b/prisma/migrations/20251217181257_fix_equipment_usage_cascade_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "public"."EquipmentUsage" DROP CONSTRAINT "EquipmentUsage_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "public"."EquipmentUsage" ADD CONSTRAINT "EquipmentUsage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,12 @@ model User {
   name  String
 
   // OAuth 전용 필드
-  googleId String  @unique
+  googleId String? @unique
   avatar   String?
+
+  // 🆕 게스트 사용자 필드 추가
+  isGuest        Boolean   @default(false)
+  guestExpiresAt DateTime?
 
   createdAt DateTime   @default(now())
   favorites Favorite[]
@@ -24,7 +28,7 @@ model User {
   equipmentUsages EquipmentUsage[]
   waitingQueues   WaitingQueue[]
 
-  // 🆕 루틴 시스템 관계
+  // 루틴 시스템 관계
   workoutRoutines WorkoutRoutine[]
 
   notifications Notification[]
@@ -84,7 +88,7 @@ model EquipmentUsage {
 
   createdAt DateTime @default(now())
 
-  user      User      @relation(fields: [userId], references: [id], onDelete: Restrict)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   equipment Equipment @relation(fields: [equipmentId], references: [id], onDelete: Restrict)
 
   @@index([equipmentId, status])
@@ -103,6 +107,7 @@ model WaitingQueue {
 
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   equipment Equipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+
   @@index([equipmentId, queuePosition])
   @@index([equipmentId, status])
 }
@@ -137,37 +142,37 @@ model RoutineExercise {
   routine   WorkoutRoutine @relation(fields: [routineId], references: [id], onDelete: Cascade)
   equipment Equipment      @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
 
- // 한 루틴에 같은 기구 중복 방지
+  // 한 루틴에 같은 기구 중복 방지
   @@unique([routineId, order]) //한 루틴에서 순서는 중복 불가
   @@index([routineId, order])
 }
 
 model Notification {
-  id          Int      @id @default(autoincrement())
-  userId      Int
-  type        String   // EQUIPMENT_AVAILABLE, REST_STARTED, NEXT_SET_STARTED, EXERCISE_STOPPED 등
-  category    String   // queue, workout, eta, other
-  priority    Int      @default(5) // 1-10
-  
-  title       String
-  message     String
-  isRead      Boolean  @default(false)
-  
+  id       Int    @id @default(autoincrement())
+  userId   Int
+  type     String // EQUIPMENT_AVAILABLE, REST_STARTED, NEXT_SET_STARTED, EXERCISE_STOPPED 등
+  category String // queue, workout, eta, other
+  priority Int    @default(5) // 1-10
+
+  title   String
+  message String
+  isRead  Boolean @default(false)
+
   // 관련 정보
   equipmentId   Int?
   equipmentName String?
   queueId       Int?
   usageId       Int?
-  
+
   // 메타데이터 (JSON으로 추가 정보 저장)
-  metadata    Json?
-  
-  createdAt   DateTime @default(now())
-  readAt      DateTime?
-  
-  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  equipment   Equipment? @relation(fields: [equipmentId], references: [id], onDelete: SetNull)
-  
+  metadata Json?
+
+  createdAt DateTime  @default(now())
+  readAt    DateTime?
+
+  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  equipment Equipment? @relation(fields: [equipmentId], references: [id], onDelete: SetNull)
+
   @@index([userId, createdAt])
   @@index([userId, isRead])
   @@index([userId, category])

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -26,6 +26,50 @@ router.get('/google/callback',
   },
 );
 
+// 🆕 POST /api/auth/guest - 게스트 로그인
+router.post('/guest', asyncRoute(async (req, res) => {
+  const guestName = `Guest_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const guestEmail = `${guestName.toLowerCase()}@guest.temp`;
+  
+  // 게스트 계정 생성 (12시간 후 자동 삭제)
+  const expiresAt = new Date();
+  expiresAt.setHours(expiresAt.getHours() + 12);
+  
+  const guestUser = await prisma.user.create({
+    data: {
+      email: guestEmail,
+      name: guestName,
+      googleId: null,
+      isGuest: true,
+      guestExpiresAt: expiresAt,
+      avatar: null
+    }
+  });
+
+  // JWT 토큰 생성
+  const token = jwt.sign(
+    { 
+      id: guestUser.id, 
+      email: guestUser.email,
+      isGuest: true 
+    },
+    process.env.JWT_SECRET,
+    { expiresIn: '12h' }
+  );
+
+  res.json({
+    message: '게스트로 로그인했습니다',
+    token,
+    user: {
+      id: guestUser.id,
+      email: guestUser.email,
+      name: guestUser.name,
+      isGuest: true,
+      expiresAt: guestUser.guestExpiresAt
+    }
+  });
+}));
+
 // POST /api/auth/logout
 router.post('/logout', (req, res) => {
   req.logout((err) => {


### PR DESCRIPTION
## PR 설명
### 무엇을 했나
- 버튼 클릭만으로 게스트 계정 즉시 생성
- 게스트 이름을 `Guest_{timestamp}_{randomString}` 형식으로 생성해 고유성 보장
- 게스트 계정은 기본 12시간 후 만료/삭제 (설정으로 시간 조정 가능)
- 게스트도 일반 사용자와 동일한 권한으로 기능 사용 가능
- 30분마다 스케줄러로 만료된 게스트 계정 자동 정리
- DB Cascade 설정으로 게스트 계정 삭제 시 연관 데이터도 함께 삭제되도록 처리

### 동작 방식 요약
1) 게스트 로그인 버튼 클릭 → 게스트 유저 생성 및 로그인 토큰 발급  
2) `guestExpiresAt` 기준으로 만료 시간 관리  
3) 스케줄러가 30분마다 만료 유저 삭제  
4) Cascade로 연관 데이터 자동 정리

## 커밋 메시지(옵션)
feat: add expiring guest login with scheduled cleanup and cascade deletion
